### PR TITLE
Fixed form ordering for inline forms.

### DIFF
--- a/app/views/recipes/_direction_fields.html.erb
+++ b/app/views/recipes/_direction_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="form-inline clearfix">
   <div class="nested-fields">
-    <%= f.input :step, input_html: { class: "form-input form-control" } %>
-    <%= link_to_remove_association "Remove Step", f, class: "btn btn-default form-button" %>
+    <%= f.input :step %>
+    <%= link_to_remove_association "Remove Step", f, class: "btn btn-default" %>
   </div>
 </div>

--- a/app/views/recipes/_ingredient_fields.html.erb
+++ b/app/views/recipes/_ingredient_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="form-inline clearfix">
   <div class="nested-fields">
-    <%= f.input :name, input_html: { class: "form-input form-control" } %>
-    <%= link_to_remove_association "Remove Ingredient", f, class: "btn btn-default form-button" %>
+    <%= f.input :name %>
+    <%= link_to_remove_association "Remove Ingredient", f, class: "btn btn-default" %>
   </div>
 </div>


### PR DESCRIPTION
I think this was potentially caused by the newer version of bootstrap. Tested locally, screenshot attached.

Relevant bootstrap docs: https://getbootstrap.com/docs/3.3/css/#forms-inline

![screenshot from 2017-10-02 18 10 41](https://user-images.githubusercontent.com/694549/31106047-4b3e6d3a-a79d-11e7-9d0e-088dc2e2a5f7.png)
